### PR TITLE
Ensure that show output is parsed correctly

### DIFF
--- a/legacy/check_3ware_raid.py
+++ b/legacy/check_3ware_raid.py
@@ -229,7 +229,11 @@ def test_drives(verbosity, no_summary=False):
     on the local machine"""
 
     lines = run("show")
-    controllers = [ line.split()[0] for line in lines ]
+    controllers = []
+    for line in lines:
+        parts = line.split()
+        if len(parts):
+            controllers.append(parts[0])
 
     status = OK
     message = ""


### PR DESCRIPTION
With newer revs of the tw_cli client, some lines in the 'show' output
may, in fact, be blank. Thus we cannot assume that a split on a blank
line will be correct. Therefore, check that the line actually has
content during the parse.
