### PR TITLE
Support riak stats that end in numeric digits

### DIFF
--- a/check_riak_stats.pl
+++ b/check_riak_stats.pl
@@ -61,7 +61,7 @@ if($all_metrics){
 } else {
     defined($metrics) or usage "no metrics specified";
     foreach my $metric (split(/\s*[,\s]\s*/, $metrics)){
-        $metric =~ /^[A-Z]+[\w:]*[A-Z]+$/i or usage "invalid metrics '$metric' given, must be alphanumeric, may contain underscores and colons in middle";
+        $metric =~ /^[A-Z]+[\w:]*[A-Z0-9]+$/i or usage "invalid metrics '$metric' given, must be alphanumeric, may contain underscores and colons in middle";
         grep(/^$metric$/, @stats) or push(@stats, $metric);
     }
     @stats or usage "no valid metrics specified";


### PR DESCRIPTION
The check_riak_stats.pl script attempts to validate metrics passed to it, but does not take into account those ending in numeric digits, for example: node_get_fsm_time_100.
