### PR TITLE
Add new valid status "serverTransferProhibited"

### DIFF
--- a/check_whois.pl
+++ b/check_whois.pl
@@ -220,6 +220,7 @@ my @valid_statuses = qw/
                         clientRenewProhibited
                         clientTransferProhibited
                         clientUpdateProhibited
+                        serverTransferProhibited
                         connect
                         ok
                         published


### PR DESCRIPTION
The registrar Tucows will use this status for domains that were transferred via their OpenSRS reseller program, while the domain is in its 60-day transfer waiting period.

Here is the output for a sample domain that is in this state:

```
$ whois c3pa.org
Domain Name:C3PA.ORG
Domain ID: D122565311-LROR
Creation Date: 2006-05-16T13:02:36Z
Updated Date: 2014-12-27T18:57:58Z
Registry Expiry Date: 2016-05-16T13:02:36Z
Sponsoring Registrar:Tucows Inc. (R11-LROR)
Sponsoring Registrar IANA ID: 69
WHOIS Server:
Referral URL:
Domain Status: clientTransferProhibited
Domain Status: clientUpdateProhibited
Domain Status: serverTransferProhibited
Domain Status: transferPeriod
```

Without this patch, here is the critical error that is raised for the domain above by `check_whois.pl`:

```
CRITICAL: domain mismatch!!! (expected 'c3pa.org', got 'ID') invalid status 'serverTransferProhibited' found! 503 days left for c3pa.org domain, expires '16-05-2016' 
```

Note that the domain is valid, active, and has an expiration date that is in the future.
