### PR TITLE
Cassandra 3.4 report value with percent sign / HBase JSP new format

### DIFF
--- a/check_cassandra_balance.pl
+++ b/check_cassandra_balance.pl
@@ -72,6 +72,7 @@ foreach(@output){
         $node_count++;
         my $node       = $1;
         my $percentage = $2;
+        $percentage =~ tr/%//d;
         my $rack       = $3;
         if($percentage eq "?"){
             quit "UNKNOWN", "nodetool returned '?' for token percentage ownership, Cassandra can't determine it's own token % we need to calculate the balance";

--- a/check_hbase_regionservers_jsp.pl
+++ b/check_hbase_regionservers_jsp.pl
@@ -77,7 +77,7 @@ foreach(split("\n", $content)){
         $live_servers_section = 1;
     }
     next unless $live_servers_section;
-    if(/<tr><th>Total: <\/th><td>servers: (\d+)<\/td>/){
+    if(/<tr><td>Total:(\d+)<\/td>/){
         $live_servers = $1;
         last;
     }


### PR DESCRIPTION
Hello,

I had this issue after deploying your script on my server. It seems that newer Cassandra report this value as a %, not as a float.
I'm not a PERL expert at all so you may want to do something else but this line fixed the issue for me.

Best regards, Adam.