### PR TITLE
Support Impala CDH > 5.4

### DIFF
--- a/check_impala_metrics.pl
+++ b/check_impala_metrics.pl
@@ -74,7 +74,9 @@ $status = "OK";
 # Impala 1.0 / 1.0.1 doesn't currently support &raw on this URI handler
 #my $url = "http://$host:$port/metrics";
 # switched to /jsonmetrics
-my $url = "http://$host:$port/jsonmetrics";
+# Impala 1.0 / 1.0.1 doesn't currently support &raw on this URI handler
+# Impala since CDH 5.4 switched to jsonmetrics?json
+my $url = "http://$host:$port/jsonmetrics?json";
 
 my $content = curl $url, "Impala debug UI metrics";
 


### PR DESCRIPTION
Cloudera Impala since CDH 5.4 supports only /jsonmetrics?json handler otherwise it returns "Could not open template: /usr/lib/impala//www//legacy-metrics.tmpl": https://community.cloudera.com/t5/Interactive-Short-cycle-SQL/Could-not-open-template-usr-lib-impala-www-legacy-metrics-tmpl/td-p/26815
