### PR TITLE
check_yum.py: check if we must run as root

### DIFF
--- a/check_yum.py
+++ b/check_yum.py
@@ -178,7 +178,10 @@ class YumTester(object):
         with an appropriate message if any are found"""
 
         if returncode == 0:
-            pass
+            if "You must run this command as root" in output[2]:
+                end(UNKNOWN, "You must run this plugin as root")
+            else:
+                pass
         elif returncode == 100:
             # Updates Available
             pass


### PR DESCRIPTION
If you run 'yum check-update' on RedHat as non root user you get this
message, sadly with a returncode of 0:

*Note* Red Hat Network repositories are not listed below. You must run
this command as root to access RHN repositories.

The current output parsing interpreted this as:

YUM OK: 0 Security Updates Available

which is wrong.