### PR TITLE
Fix cassandra netstats check regex

### DIFF
--- a/check_cassandra_netstats.pl
+++ b/check_cassandra_netstats.pl
@@ -70,7 +70,7 @@ if($i >= scalar @output){
 my %stats;
 foreach(; $i < scalar @output; $i++){
     $output[$i] =~ /^\s*$/ and $i++ and last;
-    $output[$i] =~ /^(\w+(?:\s[A-Za-z]+)?)\s+(n\/a|\d+)\s+(\d+)\s+(\d+)(?:\s+(\d+))?\s*$/i or die_nodetool_unrecognized_output($output[$i]);
+    $output[$i] =~ /^(\w+(?:\s[A-Za-z]+)?)\s+(n\/a|\d+)\s+(\d+)\s+(\d+)(?:\s+(n\/a|\d+))?\s*$/i or die_nodetool_unrecognized_output($output[$i]);
     my $type = $1;
     my $active = $2;
     my $pending = $3;


### PR DESCRIPTION
Fails to run when Dropped column has `n/a`

```
$ /etc/sensu/plugins/harisekhon/check_cassandra_netstats.pl -H 127.0.0.1 -P 7199 -u cassandra -p cassandra
UNKNOWN: unrecognized output 'Responses                       n/a         3        3545563       n/a'
```

Actual netstats output
```
$ nodetool netstats
Mode: NORMAL
Not sending any streams.
Read Repair Statistics:
Attempted: 587
Mismatch (Blocking): 0
Mismatch (Background): 0
Pool Name                    Active   Pending      Completed   Dropped
Commands                        n/a         3          72352         0
Responses                       n/a         3        3545912       n/a
```