### PR TITLE
Added quotes around $output variable (handle asterisk in output)

### DIFF
--- a/older/nsca_wrapper.sh
+++ b/older/nsca_wrapper.sh
@@ -223,7 +223,7 @@ which ${cmd%% *} >/dev/null 2>&1 || die "Command not found: ${cmd%% *}"
 output="`$cmd 2>&1`"
 result=$?
 [ "$quiet_mode" = "true" ] || echo "$output"
-output="`echo $output | sed 's/%/%%/g'`"
+output="`echo "$output" | sed 's/%/%%/g'`"
 
 if [ "$local_passive" = "true" ]; then
     nagios_result="PROCESS_SERVICE_CHECK_RESULT;$host;$service;$result;$output"


### PR DESCRIPTION
If plugin output contains asterisk in its body, it would be expanded in the echo command. E.g. output like:
    * elasticsearch is running
would return list of files in the working directory before the "elasticsearch is running" text.