### PR TITLE
adding support for SSL encryption and username/password authentication

### DIFF
--- a/check_elasticsearch.pl
+++ b/check_elasticsearch.pl
@@ -42,6 +42,8 @@ my $lc_version_regex;
     "C|cluster=s"       => [ \$cluster,           "Cluster to expect membership of (optional, available from 1.3" ],
     "es-version=s"      => [ \$es_version_regex,  "Elasticsearch version regex to expect (optional)" ],
     "lucene-version=s"  => [ \$lc_version_regex,  "Lucene version regex to expect (optional)" ],
+    %useroptions,
+    %ssloptions,
 );
 splice @usage_order, 6, 0, qw/cluster es-version lucene-version/;
 

--- a/check_elasticsearch_cluster_disk_balance.pl
+++ b/check_elasticsearch_cluster_disk_balance.pl
@@ -34,6 +34,8 @@ set_threshold_defaults(20, 80);
 %options = (
     %hostoptions,
     %thresholdoptions,
+    %useroptions,
+    %ssloptions,
 );
 
 get_options();

--- a/check_elasticsearch_cluster_shard_balance.pl
+++ b/check_elasticsearch_cluster_shard_balance.pl
@@ -38,6 +38,8 @@ set_threshold_defaults(30, 200);
 %options = (
     %hostoptions,
     %thresholdoptions,
+    %useroptions,
+    %ssloptions,
 );
 
 get_options();

--- a/check_elasticsearch_cluster_shards.pl
+++ b/check_elasticsearch_cluster_shards.pl
@@ -43,6 +43,8 @@ my $unassigned_shard_thresholds = "0,1";
     "relocating-shards=s"       =>  [ \$relocating_shard_thresholds,        "Relocating Shards upper thresholds (inclusive, default w,c: 0,0:)" ],
     "initializing-shards=s"     =>  [ \$initializing_shard_thresholds,      "Initializing Shards upper thresholds (inclusive, default w,c: 0,0:)" ],
     "unassigned-shards=s"       =>  [ \$unassigned_shard_thresholds,        "Unassigned Shards upper thresholds (inclusive, default w,c: 0,1)" ],
+    %useroptions,
+    %ssloptions,
 );
 splice @usage_order, 6, 0, qw/cluster-name active-primary-shards active-shards relocating-shards initializing-shards unassigned-shards/;
 

--- a/check_elasticsearch_cluster_stats.pl
+++ b/check_elasticsearch_cluster_stats.pl
@@ -44,6 +44,8 @@ my $expected_value;
     %hostoptions,
     "K|key=s"   => [ \$keys,            "Stat Key(s) to fetch (eg. indices.count, indices.docs.count, nodes.fs.disk_writes, nodes.fs.free_in_bytes). Multiple keys may be comma separated. Optional, all stats will be printed if no specific stat(s) requested" ],
     %thresholdoptions,
+    %useroptions,
+    %ssloptions,
 );
 
 get_options();

--- a/check_elasticsearch_cluster_status.pl
+++ b/check_elasticsearch_cluster_status.pl
@@ -33,6 +33,8 @@ my $cluster;
 %options = (
     %hostoptions,
     "C|cluster-name=s" => [ \$cluster, "Cluster name to expect (optional). Cluster name is used for auto-discovery and should be unique to each cluster in a single network" ],
+    %useroptions,
+    %ssloptions,
 );
 splice @usage_order, 6, 0, qw/cluster-name/;
 

--- a/check_elasticsearch_cluster_status_nodes_shards.pl
+++ b/check_elasticsearch_cluster_status_nodes_shards.pl
@@ -54,6 +54,8 @@ my $unassigned_shard_thresholds = "0,1";
     "relocating-shards=s"       =>  [ \$relocating_shard_thresholds,        "Relocating Shards upper thresholds (inclusive, default w,c: 0,0:)" ],
     "initializing-shards=s"     =>  [ \$initializing_shard_thresholds,      "Initializing Shards upper thresholds (inclusive, default w,c: 0,0:)" ],
     "unassigned-shards=s"       =>  [ \$unassigned_shard_thresholds,        "Unassigned Shards upper thresholds (inclusive, default w,c: 0,1)" ],
+    %useroptions,
+    %ssloptions,
 );
 splice @usage_order, 6, 0, qw/cluster-name nodes data-nodes active-primary-shards active-shards relocating-shards initializing-shards unassigned-shards/;
 

--- a/check_elasticsearch_data_nodes.pl
+++ b/check_elasticsearch_data_nodes.pl
@@ -36,6 +36,8 @@ my $cluster;
     %hostoptions,
     "C|cluster-name=s" =>  [ \$cluster, "Cluster name to expect (optional). Cluster name is used for auto-discovery and should be unique to each cluster in a single network" ],
     %thresholdoptions,
+    %useroptions,
+    %ssloptions,
 );
 splice @usage_order, 6, 0, qw/cluster-name/;
 

--- a/check_elasticsearch_doc_count.pl
+++ b/check_elasticsearch_doc_count.pl
@@ -33,6 +33,8 @@ $ua->agent("Hari Sekhon $progname version $main::VERSION");
     %hostoptions,
     %elasticsearch_index,
     %thresholdoptions,
+    %useroptions,
+    %ssloptions,
 );
 
 get_options();

--- a/check_elasticsearch_fielddata.pl
+++ b/check_elasticsearch_fielddata.pl
@@ -39,6 +39,8 @@ my $list_nodes;
     "N|node=s"    => [ \$node,       "Node hostname or IP address of node for which to check fielddata volume" ],
     "list-nodes"  => [ \$list_nodes, "List nodes (this API no longer returns nodes without fielddata from 5.0 onwards, use --list from one of the adjacent plugins instead)" ],
     %thresholdoptions,
+    %useroptions,
+    %ssloptions,
 );
 push(@usage_order, qw/node list-nodes/);
 

--- a/check_elasticsearch_index_age.pl
+++ b/check_elasticsearch_index_age.pl
@@ -31,6 +31,8 @@ $ua->agent("Hari Sekhon $progname version $main::VERSION");
     %hostoptions,
     %elasticsearch_index,
     %thresholdoptions,
+    %useroptions,
+    %ssloptions,
 );
 
 get_options();

--- a/check_elasticsearch_index_exists.pl
+++ b/check_elasticsearch_index_exists.pl
@@ -30,6 +30,8 @@ $ua->agent("Hari Sekhon $progname version $main::VERSION");
 %options = (
     %hostoptions,
     %elasticsearch_index,
+    %useroptions,
+    %ssloptions,
 );
 
 get_options();

--- a/check_elasticsearch_index_replicas.pl
+++ b/check_elasticsearch_index_replicas.pl
@@ -35,6 +35,8 @@ set_threshold_defaults(1,0);
     %elasticsearch_index,
     #"R|replicas=s" => [ \$expected_replicas, "Expected replicas (default: w,c = 1,0)" ],
     %thresholdoptions,
+    %useroptions,
+    %ssloptions,
 );
 
 get_options();

--- a/check_elasticsearch_index_settings.pl
+++ b/check_elasticsearch_index_settings.pl
@@ -44,6 +44,8 @@ my $expected_value;
     #"K|key=s"      =>  [ \$key,                "Setting key to check (eg. index.refresh_interval), will be prefixed with 'index.' if not starting with index for convenience of being able to use shorter keys" ],
     "K|key=s"      =>  [ \$key,                "Setting key to check (eg. index.refresh_interval)" ],
     "L|value=s"    =>  [ \$expected_value,     "Expected setting value (optional, eg. 30, use 'default' to check the key doesn't exist which implies default value)" ],
+    %useroptions,
+    %ssloptions,
 );
 
 get_options();

--- a/check_elasticsearch_index_shards.pl
+++ b/check_elasticsearch_index_shards.pl
@@ -33,6 +33,8 @@ my $expected_shards;
     %hostoptions,
     %elasticsearch_index,
     "A|shards=s" => [ \$expected_shards, "Expected shards (optional)" ],
+    %useroptions,
+    %ssloptions,
 );
 
 get_options();

--- a/check_elasticsearch_index_stats.pl
+++ b/check_elasticsearch_index_stats.pl
@@ -46,6 +46,8 @@ my $expected_value;
     "K|key=s"   => [ \$keys,            "Stat Key(s) to fetch (eg. total.docs.count, total.docs.deleted). Multiple keys may be comma separated, will be prefixed with 'total.' if not already starting with 'primaries' or 'total'. Optional, all 'total' stats will be printed if no specific stat(s) requested, can specify just 'primaries' to fetch all primaries stats instead of totals" ],
     #"shorten"   => [ \$shorten,        "Shorten key names using sections: instead of duplicating the full stat key name prefixes for every stat" ],
     %thresholdoptions,
+    %useroptions,
+    %ssloptions,
 );
 
 get_options();

--- a/check_elasticsearch_master_node.pl
+++ b/check_elasticsearch_master_node.pl
@@ -34,6 +34,8 @@ my $node;
 %options = (
     %hostoptions,
     "N|node=s" => [ \$node, "Hostname or IP address of node for which to expect as master, raises warning if a different master node is found to alert us to a possible failover event. Optional" ],
+    %useroptions,
+    %ssloptions,
 );
 push(@usage_order, qw/node/);
 

--- a/check_elasticsearch_node_disk_percent.pl
+++ b/check_elasticsearch_node_disk_percent.pl
@@ -41,6 +41,8 @@ set_threshold_defaults(75, 90);
     %hostoptions,
     %elasticsearch_node,
     %thresholdoptions,
+    %useroptions,
+    %ssloptions,
 );
 
 get_options();

--- a/check_elasticsearch_node_shards.pl
+++ b/check_elasticsearch_node_shards.pl
@@ -39,6 +39,8 @@ set_threshold_defaults("1:", 10000);
     %hostoptions,
     %elasticsearch_node,
     %thresholdoptions,
+    %useroptions,
+    %ssloptions,
 );
 
 get_options();

--- a/check_elasticsearch_node_stats.pl
+++ b/check_elasticsearch_node_stats.pl
@@ -45,6 +45,8 @@ my $expected_value;
     %elasticsearch_node,
     "K|key=s" => [ \$keys, "Stat Key(s) to fetch (eg. indices.docs.count, http.current_open, fs.total.available_in_bytes). Multiple keys may be comma separated. Optional, all stats will be printed if no specific stat(s) requested" ],
     %thresholdoptions,
+    %useroptions,
+    %ssloptions,
 );
 
 get_options();

--- a/check_elasticsearch_nodes.pl
+++ b/check_elasticsearch_nodes.pl
@@ -36,6 +36,8 @@ my $cluster;
     %hostoptions,
     "C|cluster-name=s" =>  [ \$cluster, "Cluster name to expect (optional). Cluster name is used for auto-discovery and should be unique to each cluster in a single network" ],
     %thresholdoptions,
+    %useroptions,
+    %ssloptions,
 );
 splice @usage_order, 6, 0, qw/cluster-name/;
 

--- a/check_elasticsearch_pending_tasks.pl
+++ b/check_elasticsearch_pending_tasks.pl
@@ -36,6 +36,8 @@ set_threshold_defaults("0:20", 30);
 %options = (
     %hostoptions,
     %thresholdoptions,
+    %useroptions,
+    %ssloptions,
 );
 
 get_options();

--- a/check_elasticsearch_shards_state_detail.pl
+++ b/check_elasticsearch_shards_state_detail.pl
@@ -30,6 +30,8 @@ $ua->agent("Hari Sekhon $progname version $main::VERSION");
     %hostoptions,
     %elasticsearch_index,
     %multilineoption,
+    %useroptions,
+    %ssloptions,
 );
 $options{"I|index=s"}[1] .= ", defaults to showing all indices if unspecified";
 splice @usage_order, 6, 0, qw/index/;


### PR DESCRIPTION
For monitoring secured ElasticSearch clusters using Elastic X-Pack or
SearchGuard security

Depends on:
https://github.com/ted3/lib/commit/8feab91751167f188a24764e073c7318e83b8f97

I tested these with ElasticSearch 5.5.1 with SearchGuard TLS and authentication as well as an unsecured cluster to confirm existing functionality is unchanged