### PR TITLE
Cherry branch

### DIFF
--- a/check_cassandra_nodes.pl
+++ b/check_cassandra_nodes.pl
@@ -34,7 +34,7 @@ BEGIN {
     use lib dirname(__FILE__) . "/lib";
 }
 use HariSekhonUtils qw/:DEFAULT :regex/;
-use HariSekhon::Cassandra::Nodetool2;
+use HariSekhon::Cassandra::Nodetool;
 
 set_threshold_defaults(0, 1);
 

--- a/check_cassandra_nodes.pl
+++ b/check_cassandra_nodes.pl
@@ -11,6 +11,10 @@
 
 # TODO: check if I can rewrite a version of this via API
 
+# Modified by: Dragan Milchevski 26.06.2017
+# Allowed checking multiple hots in a case one host is down, the others hosts might provide the desired status information.
+# If all hosts are down, a CRITICAL message is returned.
+
 my $max_num_down_nodes_to_output = 5;
 
 $DESCRIPTION = "Nagios Plugin to check the number of available cassandra nodes and raise warning/critical on down nodes.
@@ -30,7 +34,7 @@ BEGIN {
     use lib dirname(__FILE__) . "/lib";
 }
 use HariSekhonUtils qw/:DEFAULT :regex/;
-use HariSekhon::Cassandra::Nodetool;
+use HariSekhon::Cassandra::Nodetool2;
 
 set_threshold_defaults(0, 1);
 
@@ -42,19 +46,10 @@ splice @usage_order, 0, 0, 'nodetool';
 
 get_options();
 
-($nodetool, $host, $port, $user, $password) = validate_nodetool_options($nodetool, $host, $port, $user, $password);
-validate_thresholds(undef, undef, { "simple" => "upper", "integer" => 1, "positive" => 1});
-
-vlog2;
-set_timeout();
-
-$status = "OK";
-
-my $options = nodetool_options($host, $port, $user, $password);
-my $cmd     = "${nodetool} ${options}status";
-
-vlog2 "fetching cluster nodes information";
-my @output = cmd($cmd);
+#In case of multiple hosts, separated by comma ","
+my @hosts = split ',', $host;
+my $connection_refused = 0;
+my $is_refused = 0;
 
 my $up_nodes      = 0;
 my $down_nodes    = 0;
@@ -66,71 +61,109 @@ my $moving_nodes  = 0;
 my @down_nodes;
 my $node_address;
 
-sub parse_state ($) {
-    # Don't know what remote JMX auth failure looks like yet so will go critical on any user/password related message returned assuming that's an auth failure
-    check_nodetool_errors($_);
-    if(/^[UD][NLJM]\s+($host_regex)/){
+#Loop through all hosts
+foreach(@hosts){
+    $host = $_;
+
+    ($nodetool, $host, $port, $user, $password) = validate_nodetool_options($nodetool, $host, $port, $user, $password);
+    validate_thresholds(undef, undef, { "simple" => "upper", "integer" => 1, "positive" => 1});
+
+    vlog2;
+    set_timeout();
+
+    $status = "OK";
+
+    my $options = nodetool_options($host, $port, $user, $password);
+    my $cmd     = "${nodetool} ${options}status";
+
+    vlog2 "fetching cluster nodes information";
+    my @output = cmd($cmd);
+
+    $up_nodes      = 0;
+    $down_nodes    = 0;
+    $normal_nodes  = 0;
+    $leaving_nodes = 0;
+    $joining_nodes = 0;
+    $moving_nodes  = 0;
+
+
+    sub parse_state ($) {
+      $is_refused = 0;
+      # Don't know what remote JMX auth failure looks like yet so will go critical on any user/password related message returned assuming that's an auth failure
+      check_nodetool_errors($_);
+      if(/^[UD][NLJM]\s+($host_regex)/){
         $node_address = $1;
-        if(/^U/){
-            $up_nodes++;
-        } elsif(/^D/){
+          if(/^U/){
+              $up_nodes++;
+          } elsif(/^D/){
             $down_nodes++;
             push(@down_nodes, $node_address);
-        }
-        if(/^.N/){
+          }
+          if(/^.N/){
             $normal_nodes++;
-        } elsif(/^.L/){
+          } elsif(/^.L/){
             $leaving_nodes++;
-        } elsif(/^.J/){
+          } elsif(/^.J/){
             $joining_nodes++;
-        } elsif(/^.M/){
+          } elsif(/^.M/){
             $moving_nodes++;
-        } else {
+          } else {
             quit "UNKNOWN", "unrecognized second column for node status, $nagios_plugins_support_msg";
-        }
-        return 1;
-    } elsif($_ =~ $nodetool_status_header_regex){
-       # ignore
-    } elsif(skip_nodetool_output($_)){
+          }
+          return 1;
+      } elsif($_ =~ $nodetool_status_header_regex){
+         # ignore
+      } elsif(skip_nodetool_output($_)){
         # ignore
-    } else {
+      } elsif(skip_connection_refused($_)){
+   	$connection_refused++;
+	$is_refused = 1;
+      } else {
         die_nodetool_unrecognized_output($_);
+      }
     }
-}
 
-foreach(@output){
-    parse_state($_);
-}
+    foreach(@output){
+      parse_state($_);
+    }
 
-vlog2 "checking node counts and number of nodes down";
-if(@down_nodes){
-    quit "UNKNOWN", "inconsistent nodes down count vs nodes down addresses, probably a parsing error in parse_state(). $nagios_plugins_support_msg" unless $down_nodes;
-    plural $down_nodes;
-    vlog2("$down_nodes node$plural down: " . join(", ", @down_nodes) );
-}
-unless( ($up_nodes + $down_nodes ) == ($normal_nodes + $leaving_nodes + $joining_nodes + $moving_nodes)){
-    quit "UNKNOWN", "live+down node counts vs (normal/leaving/joining/moving) nodes are not equal, investigation required";
-}
+    vlog2 "checking node counts and number of nodes down";
+    if(@down_nodes){
+      quit "UNKNOWN", "inconsistent nodes down count vs nodes down addresses, probably a parsing error in parse_state(). $nagios_plugins_support_msg" unless $down_nodes;
+      plural $down_nodes;
+      vlog2("$down_nodes node$plural down: " . join(", ", @down_nodes) );
+    }
+    unless( ($up_nodes + $down_nodes ) == ($normal_nodes + $leaving_nodes + $joining_nodes + $moving_nodes)){
+      quit "UNKNOWN", "live+down node counts vs (normal/leaving/joining/moving) nodes are not equal, investigation required";
+    }
 
-$msg = "$up_nodes nodes up, $down_nodes down";
-check_thresholds($down_nodes);
-if($verbose and @down_nodes){
-    plural scalar @down_nodes;
-    $msg .= " [node$plural down: ";
-    if(scalar @down_nodes > $max_num_down_nodes_to_output){
+    $msg = "$up_nodes nodes up, $down_nodes down";
+    check_thresholds($down_nodes);
+    if($verbose and @down_nodes){
+      plural scalar @down_nodes;
+      $msg .= " [node$plural down: ";
+      if(scalar @down_nodes > $max_num_down_nodes_to_output){
         for(my $i; $i < $max_num_down_nodes_to_output; $i++){
             $msg .= ", " . $down_nodes[$i];
         }
         $msg .= " ... ";
-    } else {
+      } else {
         $msg .= join(", ", @down_nodes);
+      }
+      $msg .= "]";
     }
-    $msg .= "]";
-}
-$msg .= ", node states: $normal_nodes normal, $leaving_nodes leaving, $joining_nodes joining, $moving_nodes moving";
-$msg .= " | nodes_up=$up_nodes nodes_down=$down_nodes";
-msg_perf_thresholds();
-$msg .= " normal_nodes=$normal_nodes leaving_nodes=$leaving_nodes joining_nodes=$joining_nodes moving_nodes=$moving_nodes";
+    $msg .= ", node states: $normal_nodes normal, $leaving_nodes leaving, $joining_nodes joining, $moving_nodes moving";
+    $msg .= " | nodes_up=$up_nodes nodes_down=$down_nodes";
+    msg_perf_thresholds();
+    $msg .= " normal_nodes=$normal_nodes leaving_nodes=$leaving_nodes joining_nodes=$joining_nodes moving_nodes=$moving_nodes";
 
-vlog2;
-quit $status, $msg;
+    vlog2;
+    #If a node responded, quit with the status and message from this node
+    if(not($is_refused)){
+      quit $status, $msg;
+    }
+}
+#if none of the hosts responded, quit CRITICAL
+if($connection_refused >= $#hosts) {
+    quit "CRITICAL", "All nodes down! Connection refused.";
+}


### PR DESCRIPTION
This pull-request allows for checking multiple Cassandra hosts in a cluster in a case where one host is down, the other hosts might provide the information how many nodes are up or down. If you check only one host, and it happen to be that this host is down, you cannot get notifications. The fixes allow for checking for multiple addresses, and if all hosts in the set are down, then a CRITICAL message is returned. 

This pull request also requires changes in the [Nodetool.pm](https://github.com/HariSekhon/lib/blob/301ab3042178f092cdc78344789105e7c59f8b00/HariSekhon/Cassandra/Nodetool.pm) file. I will create a separate pull request for this. The changes there are to allow skipping connection refused from down hosts, but still able to return OK if the number of up hosts is bigger then the threshold. 