### PR TITLE
FIx for https

### DIFF
--- a/setup/cpan-requirements-packaged.txt
+++ b/setup/cpan-requirements-packaged.txt
@@ -26,3 +26,4 @@ IO::Socket::SSL
 SMS::AQL
 Socket6
 URI::Escape
+LWP::Protocol::https


### PR DESCRIPTION
Fix for error connecting on https:
Protocol scheme 'https' is not supported (LWP::Protocol::https not installed)