### PR TITLE
Workaround obsolete Puppet parse_config method

### DIFF
--- a/check_puppet.rb
+++ b/check_puppet.rb
@@ -132,7 +132,11 @@ class CheckPuppet
     # should consider adding validation of the conf file to make sure it's a
     # valid puppet conf file
     Puppet[:config] = OPTIONS[:conf]
-    Puppet.parse_config
+    begin
+        Puppet.initialize_settings unless Puppet.settings.send(:global_defaults_initialized?)
+    rescue NameError
+        Puppet.parse_config
+    end
 
     if OPTIONS[:lockfile].empty?
         OPTIONS[:lockfile] = Puppet.settings.value(:agent_disabled_lockfile)


### PR DESCRIPTION
Hi Hari,

Please find attached a patch inspired from: https://github.com/petems/cucumber-puppet/commit/dd66ac1d4dd5a774ca17d639ef4f23662e5c2771

Fixing the use of an obsolete Puppet method "parse_config"

Regards,