### PR TITLE
Fix check_mesos_{master,slave}_state.pl for Mesos 1.8+

### DIFF
--- a/check_mesos_master_state.pl
+++ b/check_mesos_master_state.pl
@@ -50,7 +50,7 @@ $status = "OK";
 #         executor
 #         scheduler
 #         internal
-my $url = "http://$host:$port/state.json";
+my $url = "http://$host:$port/state";
 $json = curl_json $url, "Mesos Master state";
 vlog3 Dumper($json);
 

--- a/check_mesos_slave_state.pl
+++ b/check_mesos_slave_state.pl
@@ -49,7 +49,7 @@ $status = "OK";
 #         executor
 #         scheduler
 #         internal
-my $url = "http://$host:$port/state.json";
+my $url = "http://$host:$port/state";
 $json = curl_json $url, "Mesos Slave state";
 vlog3 Dumper($json);
 


### PR DESCRIPTION
Hi,

For some reason (annoying users ?), Mesos team decided to change the state url, removing the ".json" suffix from the URL without providing compat with the legacy url.
This quick fix make the two checks working again with Mesos 1.8 and newer, but obviously broke support for older versions.

Regards,