### PR TITLE
Fix check_puppet.rb: remove TypeError when invalid command

### DIFF
--- a/check_puppet.rb
+++ b/check_puppet.rb
@@ -109,7 +109,7 @@ class CheckPuppet
       begin
           o.parse!(ARGV)
       rescue
-          quit "UNKNOWN", "parsing error: " + $!
+          quit "UNKNOWN", "parsing error: " + $!.to_s
       end
     end
 


### PR DESCRIPTION
This PR provides a fix for the `check_puppet.rb` file.

When using the command with wrong arguments, a nice error message is supposed to be printed on the screen. Instead, the command exits with a scary TypeError exception.

### How to reproduce:

    ./check_puppet.rb --foo

### Expected result:

The output should be: `PUPPET UNKNOWN: parsing error: invalid option: --foo`.

### Actual result:
```
Traceback (most recent call last):
        6: from ./check_puppet.rb:48:in `<main>'
        5: from ./check_puppet.rb:67:in `<class:CheckPuppet>'
        4: from ./check_puppet.rb:67:in `new'
        3: from /usr/lib/ruby/2.5.0/optparse.rb:1062:in `initialize'
        2: from ./check_puppet.rb:109:in `block in <class:CheckPuppet>'
        1: from ./check_puppet.rb:112:in `rescue in block in <class:CheckPuppet>'
./check_puppet.rb:112:in `+': no implicit conversion of OptionParser::InvalidOption into String (TypeError)
```
