### PR TITLE
Fix check_gentoo_portage.py for Python 3 and Portage 3.0

### DIFF
--- a/older/check_gentoo_portage.py
+++ b/older/check_gentoo_portage.py
@@ -221,7 +221,7 @@ class PortageTester(object):
                                  % (cmd.split()[0], process.returncode, stderr))
         else:
             self.vprint(3, "Returncode: '%s'\nOutput: '%s'" % (returncode, stdout))
-            return (returncode, str(stdout).split("\n"))
+            return (returncode, str(stdout.decode()).split("\n"))
 
     def set_timeout(self):
         """sets an alarm to time out the test"""


### PR DESCRIPTION
After updating this file for python 3, it never worked for me. I found out that you need to stdout.decode() in Python3. Maybe this only occurs since Portage 3.0, I'm not sure.