### PR TITLE
Fix check_kafka when running with python3

### DIFF
--- a/check_kafka.py
+++ b/check_kafka.py
@@ -310,9 +310,9 @@ class CheckKafka(PubSubNagiosPlugin):
         log.debug('producer.send()')
         self.producer.send(
             self.topic,
-            key=self.key,
+            key=self.key.encode('utf-8'),
             partition=self.partition,
-            value=self.publish_message
+            value=self.publish_message.encode('utf-8')
             )
         log.debug('producer.flush()')
         self.producer.flush()
@@ -328,8 +328,8 @@ class CheckKafka(PubSubNagiosPlugin):
         msg = None
         try:
             for consumer_record in obj[self.topic_partition]:
-                if consumer_record.key == self.key:
-                    msg = consumer_record.value
+                if consumer_record.key == self.key.encode('utf-8'):
+                    msg = consumer_record.value.decode('utf-8')
                     break
         except KeyError:
             raise UnknownError('TopicPartition key was not found in response')


### PR DESCRIPTION
When running the script with python3 I was getting AsserionError. After some
investigation it came out the problem is with message and key not being
properly represented as bytes. The fix makes the script compatible with both
python2 and python3.

The full error I was hitting:
```
Traceback (most recent call last):
  File "/opt/python-harisekhon-utils/harisekhon/nagiosplugin/nagiosplugin.py", line 242, in main
    super(NagiosPlugin, self).main()
  File "/opt/python-harisekhon-utils/harisekhon/cli.py", line 180, in main
    self.run()
  File "./check_kafka", line 215, in run
    super(CheckKafka, self).run()
  File "/opt/python-harisekhon-utils/harisekhon/nagiosplugin/pubsub_nagiosplugin.py", line 126, in run
    self.publish()
  File "./check_kafka", line 315, in publish
    value=self.publish_message
  File "/usr/lib/python3.6/site-packages/kafka/producer/kafka.py", line 551, in send
    assert type(key_bytes) in (bytes, bytearray, memoryview, type(None))
AssertionError
```

kafka-python version: 1.4.3 (but the error was also confirmed with newer 2.0.2).