### PR TITLE
Update check_yum.py

### DIFF
--- a/check_yum.py
+++ b/check_yum.py
@@ -461,6 +461,7 @@ class YumTester(object):
              'updates? available',
              'packages? available',
              'Limiting package lists to security relevant ones',
+             'This system is receiving updates from RHN Classic or Red Hat Satellite.',
              r'Repo [\w-]+ forced skip_if_unavailable=\w+ due to',
              r'^\s*:\s+'
              ]))


### PR DESCRIPTION
Added to the excluded_regex to account for header line outputted by Spacewalk/Satellite from Yum command - otherwise it generates the "YUM WARNING: Yum output signature (7 unique lines) is larger than number of total updates (0)" error.