### PR TITLE
Remove invalid Kafka perl parameters

### DIFF
--- a/check_kafka.pl
+++ b/check_kafka.pl
@@ -202,7 +202,6 @@ try {
                                           #'timeout' => $timeout / 2,
                                           # XXX: API bug these two arguments don't allow zero attempts
                                           'SEND_MAX_ATTEMPTS'    => $send_max_attempts,
-                                          'RECEIVE_MAX_ATTEMPES' => $receive_max_attempts,
                                           'RETRY_BACKOFF'        => $retry_backoff,
                                           'AutoCreateTopicsEnable' => 0,
                                         ) or quit "CRITICAL", "failed to connect to Kafka broker$broker_name! $!";
@@ -280,7 +279,6 @@ try {
     vlog2 "connecting producer";
     $producer = Kafka::Producer->new(
                                       'Connection'    => $connection,
-                                      'CorrelationId' => int(time),
                                       'ClientId'      => "Hari Sekhon $progname version $main::VERSION",
                                       # XXX: Kafka doesn't wait for more acknowledgements than in-sync replicas
                                       'RequiredAcks'  => $RequiredAcks,


### PR DESCRIPTION
Current installed version of the Kafka perl module
is 1.08. Two parameters still in use by check_kafka.pl
were removed in v 1.001013 of the Kafka perl module, as
mentioned in the changelog:

https://metacpan.org/changes/release/ASOLOVEY/Kafka-1.08

> 1.001013 Fri Feb  24 2017
>    CHANGES:
>    - Removed support for custom CorrelationID in constructor arguments.
>    ...
>    - Removed deprecated constants $RECEIVE_MAX_ATTEMPTS, $RECEIVE_MAX_RETRIES, $SEND_MAX_RETRIES.

check_kafka.pl is erroring until these two now invalid params
are removed.