### PR TITLE
Correctly report rebuilding status

### DIFF
--- a/older/check_md_raid.py
+++ b/older/check_md_raid.py
@@ -3,7 +3,7 @@
 #  Author: Hari Sekhon
 #  Date: 2007-02-21 16:15:32 +0000 (Wed, 21 Feb 2007)
 #
-#  http://github.com/harisekhon/nagios-plugins
+#  https://github.com/harisekhon/nagios-plugins
 #
 #  License: see accompanying LICENSE file
 #
@@ -113,7 +113,7 @@ def test_raid(verbosity):
                 state = line.split(":")[-1][1:-1]
                 state = state.rstrip()
         re_clean = re.compile('^clean|active(,.*)?$')
-        if not re_clean.match(state) and state != "active":
+        if re_clean.match(state) and state != "active":
             arrays_not_ok += 1
             raidlevel = detailed_output[3].split()[-1]
             shortname = array.split("/")[-1].upper()

--- a/older/check_md_raid.py
+++ b/older/check_md_raid.py
@@ -125,7 +125,7 @@ def test_raid(verbosity):
                 extra_info = None
                 for line in detailed_output:
                     if "Rebuild Status" in line:
-                        extra_info = line
+                        extra_info = line.rstrip()
                 message += 'Array "%s" is in state ' % shortname
                 if extra_info:
                     message += '"%s" (%s) - %s' \


### PR DESCRIPTION
My mdadm output was:
```
sudo /sbin/mdadm --detail /dev/md127
/dev/md127:
        Version : 1.2
  Creation Time : Mon Jun 21 07:11:36 2021
     Raid Level : raid1
     Array Size : 732442432 (698.51 GiB 750.02 GB)
  Used Dev Size : 732442432 (698.51 GiB 750.02 GB)
   Raid Devices : 2
  Total Devices : 2
    Persistence : Superblock is persistent

  Intent Bitmap : Internal

    Update Time : Wed Jul 21 12:38:28 2021
          State : clean, degraded, recovering
 Active Devices : 1
Working Devices : 2
 Failed Devices : 0
  Spare Devices : 1

 Rebuild Status : 10% complete

           Name : <redacted>
           UUID : <redacted>
         Events : 2249

    Number   Major   Minor   RaidDevice State
       2       8       17        0      spare rebuilding   /dev/sdb1
       1       8       33        1      active sync   /dev/sdc1
```

Prior to this change, output was:
`RAID OK: All arrays OK [1 array checked]`

After it, it's:
```
RAID WARNING: 1 array not ok - Array "NEWSJBHRAV01:1" is in state "clean, degraded, recovering" (raid1) -  Rebuild Status : 12% complete
 [1 array checked]
```