### PR TITLE
check_zookeeper: accept prometheus scientific notation metrics

### DIFF
--- a/check_zookeeper.pl
+++ b/check_zookeeper.pl
@@ -277,7 +277,7 @@ foreach(sort keys %mntr){
             next;
         }
     }
-    isFloat($mntr{$_}, "negative allowed") or quit "UNKNOWN", "invalid value found for mntr $_ '$mntr{$_}'";
+    isFloat($mntr{$_}, "negative allowed") or isScientific($mntr{$_}, "negative allowed") or quit "UNKNOWN", "invalid value found for mntr $_ '$mntr{$_}'";
 }
 vlog2;
 


### PR DESCRIPTION
cf #387

For the state file, I have no solution yet. Copying the scientific regex to the multiline regex subparts doesn't match correctly, and I'm not experienced with perl.

Regarding reproduction, I'll try to make something self-contained without bitnami and/or helm