### PR TITLE
check_elasticsearch_shards_state_detail.pl - change RELOCATING to warning instead of critical

### DIFF
--- a/check_elasticsearch_shards_state_detail.pl
+++ b/check_elasticsearch_shards_state_detail.pl
@@ -93,7 +93,7 @@ $sep = "\n" if ($multiline and not $index);
 my @states = keys %shards;
 if(grep { "STARTED" ne $_ } @states){
     foreach(@states){
-        if($_ eq "STARTING" or $_ eq "INITIALIZING"){
+        if($_ eq "STARTING" or $_ eq "INITIALIZING" or $_ eq "RELOCATING"){
             warning;
         } else {
             critical;


### PR DESCRIPTION
in recent versions of ES, shard relocations are part of normal operation. They occur regularly as shards migrate between nodes with different roles (ie: HOT/WARM/COLD). Seeing relocations is useful, but they should not be reported as critical